### PR TITLE
Allow colon in attr selectors (hacky verbatim namespaces)

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ module.exports = parse;
 var re_name = /^(?:\\.|[\w\-\u00c0-\uFFFF])+/,
     re_escape = /\\([\da-f]{1,6}\s?|(\s)|.)/ig,
     //modified version of https://github.com/jquery/sizzle/blob/master/src/sizzle.js#L87
-    re_attr = /^\s*((?:\\.|[\w\u00c0-\uFFFF\-])+)\s*(?:(\S?)=\s*(?:(['"])(.*?)\3|(#?(?:\\.|[\w\u00c0-\uFFFF\-])*)|)|)\s*(i)?\]/;
+    re_attr = /^\s*((?:\\.|[:\w\u00c0-\uFFFF\-])+)\s*(?:(\S?)=\s*(?:(['"])(.*?)\3|(#?(?:\\.|[\w\u00c0-\uFFFF\-])*)|)|)\s*(i)?\]/;
 
 var actionTypes = {
 	__proto__: null,


### PR DESCRIPTION
Selectors with namespaces are not valid (although the wildcard ns, eg `img[*|src]`, should be valid). [0][1]

This hack permits colons (instead of the pipe `|` in the standard, for clarity) to be used verbatim in attribute selectors, eg:

`svg use[xlink:href]`
## 

[0] https://www.w3.org/TR/selectors-api/#namespace-prefix-needs-to-be-resolved
[1] http://stackoverflow.com/a/23047888/569150
